### PR TITLE
bump up to 0.0.8

### DIFF
--- a/openmav/mav.py
+++ b/openmav/mav.py
@@ -196,9 +196,9 @@ def main():
         type=str,
         nargs="+",
         default=[
+            "generated_text",
             "top_predictions",
             "output_distribution",
-            "generated_text",
             "mlp_activations",
             "attention_entropy",
         ],

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="openmav",
-    version="0.0.7",
+    version="0.0.8",
     packages=find_packages(),  # Automatically find packages inside the repo
     install_requires=[
         "rich",


### PR DESCRIPTION
- breaking change in UI but not in api, hence skipping a level