### PR TITLE
move to 0.0.13-rc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openmav"
-version = "0.0.12"
+version = "0.0.13-rc"
 description = "MAV: Model Activity Visualizer"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
- this helps with not conflicting pip caches for users when they do direct https installs